### PR TITLE
Added setup for YND private podspec repo

### DIFF
--- a/SocketRocket.podspec
+++ b/SocketRocket.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name               = "SocketRocket"
-  s.version            = '0.4.2'
+  s.version            = '0.4.3'
   s.summary            = 'A conforming WebSocket (RFC 6455) client library.'
   s.homepage           = 'https://github.com/square/SocketRocket'
   s.authors            = 'Square'
   s.license            = 'Apache License, Version 2.0'
-  s.source             = { :git => 'https://github.com/square/SocketRocket.git', :tag => s.version.to_s }
+  s.source             = { :git => 'https://github.com/ynd-consult-ug/SocketRocket', :tag => s.version.to_s }
   s.source_files       = 'SocketRocket/*.{h,m}'
   s.requires_arc       = true
 


### PR DESCRIPTION
JIRA: https://observatory.atlassian.net/browse/TUN-3043

What's up:

- Added setup for YND private podspec repo.
- Bumped version to `0.4.3`


----
```
 -> SocketRocket (0.4.3)
    - WARN  | github_sources: Github repositories should end in `.git`.
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Developer/ynd-consult/Pods/SocketRocket/SocketRocket/SRWebSocket.m:527:5: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Developer/ynd-consult/Pods/SocketRocket/SocketRocket/SRWebSocket.m:671:13: warning: enumeration value 'NSURLNetworkServiceTypeCallSignaling' not handled in switch [-Wswitch]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Developer/ynd-consult/Pods/SocketRocket/SocketRocket/SRWebSocket.m:1485:9: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Developer/ynd-consult/Pods/SocketRocket/SocketRocket/SRWebSocket.m:616:85: warning: values of type 'SInt32' should not be used as format arguments; add an explicit cast to 'int' instead [-Wformat]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Developer/ynd-consult/Pods/SocketRocket/SocketRocket/SRWebSocket.m:622:86: warning: values of type 'SInt32' should not be used as format arguments; add an explicit cast to 'int' instead [-Wformat]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Developer/ynd-consult/Pods/SocketRocket/SocketRocket/SRWebSocket.m:610:122: warning: implicit conversion loses integer precision: 'NSUInteger' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]

SocketRocket passed validation.
```
