### PR TITLE
Updated SOCKS version to 5

### DIFF
--- a/SocketRocket.podspec
+++ b/SocketRocket.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name               = 'SocketRocket'
-  s.version            = '0.5.3'
+  s.version            = '0.5.4'
   s.summary            = 'A conforming WebSocket (RFC 6455) client library for iOS, macOS and tvOS.'
   s.homepage           = 'https://github.com/facebook/SocketRocket'
   s.authors            = { 'Nikita Lutsenko' => 'nlutsenko@me.com', 'Dan Federman' => 'federman@squareup.com', 'Mike Lewis' => 'mikelikespie@gmail.com' }

--- a/SocketRocket/Internal/Proxy/SRProxyConnect.m
+++ b/SocketRocket/Internal/Proxy/SRProxyConnect.m
@@ -342,7 +342,7 @@
         NSMutableDictionary *settings = [NSMutableDictionary dictionary];
         settings[NSStreamSOCKSProxyHostKey] = _socksHost;
         settings[NSStreamSOCKSProxyPortKey] = @(_socksPort);
-        settings[NSStreamSOCKSProxyVersionKey] = NSStreamSOCKSProxyVersion4;
+        settings[NSStreamSOCKSProxyVersionKey] = NSStreamSOCKSProxyVersion5;
         
         [self.inputStream setProperty:settings forKey:NSStreamSOCKSProxyConfigurationKey];
         [self.outputStream setProperty:settings forKey:NSStreamSOCKSProxyConfigurationKey];


### PR DESCRIPTION
What's up:
- connecting to Tor under IPv6 network requires bridges that uses proxy SOCKS version 5
- having here version 4 causes issues with connecting to our WS API

TUN-5315